### PR TITLE
Adds support using a custom domain to bypass ad blockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Import the plugin and add it to `Vue.use`. You can add a `skip` option which wil
 import SimpleAnalytics from "simple-analytics-vue";
 import Vue from "vue";
 
-Vue.use(SimpleAnalytics, { skip: process.env.NODE_ENV !== 'production' });
+Vue.use(SimpleAnalytics, { skip: process.env.NODE_ENV !== "production" });
 ```
 
 You can also pass a function or promise to `skip` which will be validated before injecting the Simple Analytics embed code:
@@ -26,4 +26,10 @@ You can also pass a function or promise to `skip` which will be validated before
 ```js
 import auth from "lib/auth";
 Vue.use(SimpleAnalytics, { skip: auth.isAdminPromise });
+```
+
+You can also optionally specify a custom domain to bypass ad blockers. Read more about this in [our documentation](https://docs.simpleanalytics.com/bypass-ad-blockers).
+
+```js
+Vue.use(SimpleAnalytics, { domain: "api.example.com" });
 ```

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,5 @@
 /*!
- * simple-analytics-vue v1.0.4
+ * simple-analytics-vue v1.1.0
  * (c) 
  */
 'use strict';
@@ -13,29 +13,28 @@ var warn = function warn(message) {
   if (console && console.warn) console.warn('Simple Analytics: ' + message || 'Something goes wrong.');
 };
 
-var injectScript = function injectScript() {
+var injectScript = function injectScript(domain) {
   if (!document) return warn('No document defined.');
   var el = document.createElement('script');
   el.type = 'text/javascript';
   el.async = true;
-  el.src = 'https://cdn.simpleanalytics.io/hello.js';
+  el.src = 'https://' + domain + '/hello.js';
   document.head.appendChild(el);
 };
 
 var index = {
-  install: function install(vue) {
-    var _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {
-      skip: false
-    },
-        skip = _ref.skip;
-
-    if (skip === false) return injectScript(); // If skip is promise, resolve first. With failure always inject script
+  install: function install(vue, _ref) {
+    var _ref$skip = _ref.skip,
+        skip = _ref$skip === void 0 ? false : _ref$skip,
+        _ref$domain = _ref.domain,
+        domain = _ref$domain === void 0 ? 'cdn.simpleanalytics.io' : _ref$domain;
+    if (skip === false) return injectScript(domain); // If skip is promise, resolve first. With failure always inject script
 
     if (isPromise(skip)) return skip.then(function (value) {
-      if (value !== true) return injectScript();else return warn('Not sending requests because skip is active.');
+      if (value !== true) return injectScript(domain);else return warn('Not sending requests because skip is active.');
     }).catch(injectScript); // If skip function, execute and inject when not skipping
 
-    if (typeof skip === 'function' && skip() !== true) return injectScript(); // Otherwise skip
+    if (typeof skip === 'function' && skip() !== true) return injectScript(domain); // Otherwise skip
 
     return warn('Not sending requests because skip is active.');
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -15,10 +15,12 @@ var warn = function warn(message) {
 
 var injectScript = function injectScript(domain) {
   if (!document) return warn('No document defined.');
-  var el = document.createElement('script');
+  var el = document.createElement('script'); // Uses hello.js for default domain, otherwise uses app.js
+
+  var file = domain === 'cdn.simpleanalytics.io' ? 'hello' : 'app';
   el.type = 'text/javascript';
   el.async = true;
-  el.src = 'https://' + domain + '/hello.js';
+  el.src = 'https://' + domain + '/' + file + '.js';
   document.head.appendChild(el);
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-analytics-vue",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1039,13 +1039,15 @@
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
       "integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@types/babylon": {
       "version": "6.16.5",
       "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
       "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/babel-types": "*"
       }
@@ -1578,6 +1580,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1589,6 +1592,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1917,6 +1921,7 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1926,7 +1931,8 @@
           "version": "2.6.5",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
           "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1935,6 +1941,7 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
@@ -1946,7 +1953,8 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1954,7 +1962,8 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -2957,6 +2966,7 @@
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
       "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/babel-types": "^7.0.0",
         "@types/babylon": "^6.16.2",
@@ -4613,7 +4623,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4634,12 +4645,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4654,17 +4667,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4781,7 +4797,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4793,6 +4810,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4807,6 +4825,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4814,12 +4833,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4838,6 +4859,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4918,7 +4940,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4930,6 +4953,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5015,7 +5039,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5051,6 +5076,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5070,6 +5096,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5113,12 +5140,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6231,7 +6260,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -6507,7 +6537,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -8357,7 +8388,8 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.2.tgz",
       "integrity": "sha1-U659nSm7A89WRJOgJhCfVMR/XyY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pug-filters": {
       "version": "3.1.0",
@@ -8477,7 +8509,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.4.tgz",
       "integrity": "sha1-4XjhvaaKsujArPybztLFT9iM61g=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pug-strip-comments": {
       "version": "1.0.3",
@@ -8493,7 +8526,8 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.7.tgz",
       "integrity": "sha1-wA1cUSi6xYBr7BXSt+fNq+QlMfM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pump": {
       "version": "3.0.0",
@@ -8669,7 +8703,8 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "regenerator-transform": {
       "version": "0.13.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-analytics-vue",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve ./src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,11 @@ const warn = message => {
 const injectScript = (domain) => {
   if (!document) return warn('No document defined.');
   const el = document.createElement('script');
+  // Uses hello.js for default domain, otherwise uses app.js
+  const file = (domain === 'cdn.simpleanalytics.io') ? 'hello' : 'app';
   el.type = 'text/javascript';
   el.async = true;
-  el.src = 'https://' + domain + '/hello.js';
+  el.src = 'https://' + domain + '/' + file + '.js';
   document.head.appendChild(el);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,27 +6,27 @@ const warn = message => {
   if (console && console.warn) console.warn('Simple Analytics: ' + message || 'Something goes wrong.');
 }
 
-const injectScript = () => {
+const injectScript = (domain) => {
   if (!document) return warn('No document defined.');
   const el = document.createElement('script');
   el.type = 'text/javascript';
   el.async = true;
-  el.src = 'https://cdn.simpleanalytics.io/hello.js';
+  el.src = 'https://' + domain + '/hello.js';
   document.head.appendChild(el);
 }
 
 export default {
-  install(vue, { skip } = { skip: false }) {
-    if (skip === false) return injectScript()
+  install(vue, { skip = false, domain = 'cdn.simpleanalytics.io' }) {
+    if (skip === false) return injectScript(domain)
 
     // If skip is promise, resolve first. With failure always inject script
     if (isPromise(skip)) return skip.then((value) => {
-      if (value !== true) return injectScript()
+      if (value !== true) return injectScript(domain)
       else return warn('Not sending requests because skip is active.')
     }).catch(injectScript)
 
     // If skip function, execute and inject when not skipping
-    if (typeof skip === 'function' && skip() !== true) return injectScript()
+    if (typeof skip === 'function' && skip() !== true) return injectScript(domain)
 
     // Otherwise skip
     return warn('Not sending requests because skip is active.')


### PR DESCRIPTION
I added this based on the documentation here.

https://docs.simpleanalytics.com/bypass-ad-blockers

### What this PR does

1. Adds support for a optional custom domain
2. Defaults the custom domain property to the correct `cdn.simpleanalytics.io`
3. Generate a new build in `/dist` with the changes
4. Updates the readme to show the new functionality, including linking to offical docs
5. Updates the package version to `1.1.0` since this expands functionality