### PR TITLE
Add Nuxt section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ export default {
   ],
 }
 ```
-_If you need any aditional configuration options (as the ones mentioned above), you just need to apply to your plugin._
+_If you need any additional configuration options (as the ones mentioned above), you just need to apply to your plugin._

--- a/README.md
+++ b/README.md
@@ -33,3 +33,27 @@ You can also optionally specify a custom domain to bypass ad blockers. Read more
 ```js
 Vue.use(SimpleAnalytics, { domain: "api.example.com" });
 ```
+
+## Nuxt
+Since we want to 
+Create a file in your plugin folder with the name `simple-analytics.js`:
+
+```js
+// ~/plugins/simple-analytics-.js
+
+import SimpleAnalytics from "simple-analytics-vue";
+import Vue from "vue";
+
+Vue.use(SimpleAnalytics, { skip: process.env.NODE_ENV !== "production" });
+```
+
+Then on your `nuxt.config.js`, make sure to include the plugin with `ssr: false` as we only want to run it on the client:
+```js
+// nuxt.config.js
+export default {
+  plugins: [
+    { src: '~/plugins/simple-analytics.js', ssr: false }
+  ],
+}
+```
+_If you need aditional configuration options (as the ones mentioned above) you just need to apply to your plugin's contents._

--- a/README.md
+++ b/README.md
@@ -35,11 +35,10 @@ Vue.use(SimpleAnalytics, { domain: "api.example.com" });
 ```
 
 ## Nuxt
-Since we want to 
 Create a file in your plugin folder with the name `simple-analytics.js`:
 
 ```js
-// ~/plugins/simple-analytics-.js
+// ~/plugins/simple-analytics.js
 
 import SimpleAnalytics from "simple-analytics-vue";
 import Vue from "vue";
@@ -56,4 +55,4 @@ export default {
   ],
 }
 ```
-_If you need aditional configuration options (as the ones mentioned above) you just need to apply to your plugin's contents._
+_If you need any aditional configuration options (as the ones mentioned above), you just need to apply to your plugin._


### PR DESCRIPTION
This PR adds a section in the README with an explanation to import  `simple-analytics-vue` as a [Nuxt plugin](https://nuxtjs.org/guide/plugins).