### PR TITLE
Handle non prod events (when skip===true)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38,7 +38,12 @@ var index = {
       if (value !== true) return injectScript(vue, domain);else return warn("Not sending requests because skip is active.");
     }).catch(injectScript); // If skip function, execute and inject when not skipping
 
-    if (typeof skip === "function" && skip() !== true) return injectScript(vue, domain); // Otherwise skip
+    if (typeof skip === "function" && skip() !== true) return injectScript(vue, domain); // skip must be true, add event to Vue prototype to prevent errors
+
+    vue.prototype.saEvent = function (event) {
+      warn("event ".concat(event, " not tracked due to skip===true"));
+    }; // Otherwise skip
+
 
     return warn("Not sending requests because skip is active.");
   }

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,9 @@ export default {
     if (typeof skip === "function" && skip() !== true)
       return injectScript(vue, domain);
 
+    // skip must be true, add event to Vue prototype to prevent errors
+    vue.prototype.saEvent = function(event){warn(`event ${event} not tracked due to skip===true`)}
+
     // Otherwise skip
     return warn("Not sending requests because skip is active.");
   },


### PR DESCRIPTION
Added logic to prevent console errors when tracking events and `skip===true`.

Without this, when tracking events (eg: in non production environments, `window.sa_event` is undefined and hence, throwing an error)

After adding this, I wonder if it might be nice to add a way to enable/disable verbose logging. Could be an option to add later, but leaving as is for now. 