### PR TITLE
Added type definition package for typescript users

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-import type { App, Plugin } from 'vue'
+import type { App, Plugin, InjectionKey } from 'vue'
 
 declare global {
   interface Window {
@@ -11,16 +11,17 @@ export interface SimpleAnalyticsOptions {
   domain?: string;
 }
 
+export declare const saEventKey: InjectionKey<(event: string) => void>;
+
 type SimpleAnalyticsPlugin = Plugin & {
   install(app: App, options?: SimpleAnalyticsOptions): void;
 }
 
 declare const SimpleAnalytics: SimpleAnalyticsPlugin;
-
 export default SimpleAnalytics;
 
 declare module '@vue/runtime-core' {
-  interface ComponentCustomProperties {
-    $saEvent?: (event: string) => void;
+  interface InjectionKeys {
+    saEvent: (event: string) => void;
   }
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,26 @@
+import type { App, Plugin } from 'vue'
+
+declare global {
+  interface Window {
+    sa_event?: (event: string) => void;
+  }
+}
+
+export interface SimpleAnalyticsOptions {
+  skip?: boolean | (() => boolean) | Promise<boolean>;
+  domain?: string;
+}
+
+type SimpleAnalyticsPlugin = Plugin & {
+  install(app: App, options?: SimpleAnalyticsOptions): void;
+}
+
+declare const SimpleAnalytics: SimpleAnalyticsPlugin;
+
+export default SimpleAnalytics;
+
+declare module '@vue/runtime-core' {
+  interface ComponentCustomProperties {
+    $saEvent?: (event: string) => void;
+  }
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 /* globals document */
+const saEventKey = Symbol('saEvent');
 
 const isPromise = (subject) =>
   subject && subject.then && typeof subject.then == "function";
@@ -68,4 +71,5 @@ var index = {
   },
 };
 
-module.exports = index;
+exports.default = index;
+exports.saEventKey = saEventKey;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -1,4 +1,5 @@
 /* globals document */
+const saEventKey = Symbol('saEvent');
 
 const isPromise = (subject) =>
   subject && subject.then && typeof subject.then == "function";
@@ -66,4 +67,4 @@ var index = {
   },
 };
 
-export { index as default };
+export { index as default, saEventKey };

--- a/package.json
+++ b/package.json
@@ -6,10 +6,13 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "files": [
-    "dist/*"
+    "dist/*",
+    "types/*"
   ],
+  "types": "types/index.d.ts",
   "scripts": {
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "prepare-types": "cp types/index.d.ts dist/"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 /* globals document */
+export const saEventKey = Symbol('saEvent');
 
 const isPromise = (subject) =>
   subject && subject.then && typeof subject.then == "function";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import type { App, Plugin } from 'vue'
+import type { App, Plugin, InjectionKey } from 'vue'
 
 declare global {
   interface Window {
@@ -11,16 +11,17 @@ export interface SimpleAnalyticsOptions {
   domain?: string;
 }
 
+export declare const saEventKey: InjectionKey<(event: string) => void>;
+
 type SimpleAnalyticsPlugin = Plugin & {
   install(app: App, options?: SimpleAnalyticsOptions): void;
 }
 
 declare const SimpleAnalytics: SimpleAnalyticsPlugin;
-
 export default SimpleAnalytics;
 
 declare module '@vue/runtime-core' {
-  interface ComponentCustomProperties {
-    $saEvent?: (event: string) => void;
+  interface InjectionKeys {
+    saEvent: (event: string) => void;
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,26 @@
+import type { App, Plugin } from 'vue'
+
+declare global {
+  interface Window {
+    sa_event?: (event: string) => void;
+  }
+}
+
+export interface SimpleAnalyticsOptions {
+  skip?: boolean | (() => boolean) | Promise<boolean>;
+  domain?: string;
+}
+
+type SimpleAnalyticsPlugin = Plugin & {
+  install(app: App, options?: SimpleAnalyticsOptions): void;
+}
+
+declare const SimpleAnalytics: SimpleAnalyticsPlugin;
+
+export default SimpleAnalytics;
+
+declare module '@vue/runtime-core' {
+  interface ComponentCustomProperties {
+    $saEvent?: (event: string) => void;
+  }
+}

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,0 +1,282 @@
+{
+    "name": "@types/simple-analytics-vue",
+    "version": "3.0.2",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@types/simple-analytics-vue",
+            "version": "3.0.2",
+            "dependencies": {
+                "vue": "^3.0.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
+            "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.27.1"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+            "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "license": "MIT"
+        },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+            "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.25.3",
+                "@vue/shared": "3.5.13",
+                "entities": "^4.5.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.0"
+            }
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+            "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-core": "3.5.13",
+                "@vue/shared": "3.5.13"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+            "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.25.3",
+                "@vue/compiler-core": "3.5.13",
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/compiler-ssr": "3.5.13",
+                "@vue/shared": "3.5.13",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.11",
+                "postcss": "^8.4.48",
+                "source-map-js": "^1.2.0"
+            }
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+            "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/shared": "3.5.13"
+            }
+        },
+        "node_modules/@vue/reactivity": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
+            "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/shared": "3.5.13"
+            }
+        },
+        "node_modules/@vue/runtime-core": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
+            "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.13",
+                "@vue/shared": "3.5.13"
+            }
+        },
+        "node_modules/@vue/runtime-dom": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
+            "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.13",
+                "@vue/runtime-core": "3.5.13",
+                "@vue/shared": "3.5.13",
+                "csstype": "^3.1.3"
+            }
+        },
+        "node_modules/@vue/server-renderer": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
+            "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-ssr": "3.5.13",
+                "@vue/shared": "3.5.13"
+            },
+            "peerDependencies": {
+                "vue": "3.5.13"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+            "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+            "license": "MIT"
+        },
+        "node_modules/csstype": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "license": "MIT"
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "license": "MIT"
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC"
+        },
+        "node_modules/postcss": {
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.8",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/vue": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
+            "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/compiler-sfc": "3.5.13",
+                "@vue/runtime-dom": "3.5.13",
+                "@vue/server-renderer": "3.5.13",
+                "@vue/shared": "3.5.13"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        }
+    }
+}

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "@types/simple-analytics-vue",
+    "version": "3.0.2",
+    "types": "index.d.ts",
+    "dependencies": {
+      "vue": "^3.0.0"
+    }
+  }


### PR DESCRIPTION
Since we are using Vue 3 with typescript in our own project I've added types package and type definitions for typescript users. The types are shipped automatically with the vue-plugin package, but if you want you can also publish it seperately with doing `npm publish --access public` in the types directory.

Done with @kon-tilaa