### PR TITLE
fixed type definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ To send an event, inject the `saEvent` method into your Vue 3 setup script like 
 
 <script setup>
 import { inject } from "vue";
+import { saEventKey } from 'simple-analytics-vue';
 
-const saEvent = inject("saEvent");
+const saEvent = inject(saEventKey);
 
 // e.g.: send event when liking a comment
 const likeComment = (comment) => {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2,7 +2,7 @@ import type { App, Plugin, InjectionKey } from 'vue'
 
 declare global {
   interface Window {
-    sa_event?: (event: string) => void;
+    sa_event?: (event: string, metadata?: Record<string, any>) => void;
   }
 }
 
@@ -11,7 +11,7 @@ export interface SimpleAnalyticsOptions {
   domain?: string;
 }
 
-export declare const saEventKey: InjectionKey<(event: string) => void>;
+export declare const saEventKey: InjectionKey<(event: string, metadata?: Record<string, any>) => void>;
 
 type SimpleAnalyticsPlugin = Plugin & {
   install(app: App, options?: SimpleAnalyticsOptions): void;
@@ -22,6 +22,6 @@ export default SimpleAnalytics;
 
 declare module '@vue/runtime-core' {
   interface InjectionKeys {
-    saEvent: (event: string) => void;
+    saEvent: (event: string, metadata?: Record<string, any>) => void;
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@ import type { App, Plugin, InjectionKey } from 'vue'
 
 declare global {
   interface Window {
-    sa_event?: (event: string) => void;
+    sa_event?: (event: string, metadata?: Record<string, any>) => void;
   }
 }
 
@@ -11,7 +11,7 @@ export interface SimpleAnalyticsOptions {
   domain?: string;
 }
 
-export declare const saEventKey: InjectionKey<(event: string) => void>;
+export declare const saEventKey: InjectionKey<(event: string, metadata?: Record<string, any>) => void>;
 
 type SimpleAnalyticsPlugin = Plugin & {
   install(app: App, options?: SimpleAnalyticsOptions): void;
@@ -22,6 +22,6 @@ export default SimpleAnalytics;
 
 declare module '@vue/runtime-core' {
   interface InjectionKeys {
-    saEvent: (event: string) => void;
+    saEvent: (event: string, metadata?: Record<string, any>) => void;
   }
 }


### PR DESCRIPTION
I forgot to add the second possible property of sa_event in my last PR, so in the current version you weren't able to add any metadata next to the event name. This PR should fix this type definition.

I also fixed the README.md to match the current way to implement saEvent.